### PR TITLE
Add option to get Openweathermap API key from the environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following optional `args` are available:
  
 | Argument | Type | Description | Default
 | --- | --- | --- | --- |
+| `openweathermap_api_key` | string | If not provided in the theme JSON, the segment will try to use the `OPENWEATHERMAP_API_KEY` environment variable | `os.getenv("OPENWEATHERMAP_API_KEY")` |
 | `condition_as_icon` | boolean | If `true`, condition will be displayed as an icon (if one of known conditions).<br>If `false` condition will be displayed as a string | `true` |
 | `humidity_format` | string | A Python format string that accepts `humidity` as an argument | `"{humidity:.0f}"` |
 | `location_query` | string | Location in format CITY, 2-LETTERS-COUNTRY-CODE | Retrived using IP geolocation | 

--- a/powerline_owmweather/weather.py
+++ b/powerline_owmweather/weather.py
@@ -1,4 +1,5 @@
 import json
+import os
 import urllib.parse
 import time
 
@@ -7,6 +8,8 @@ from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
 from powerline.lib.url import urllib_read
+
+OPENWEATHERMAP_API_KEY = os.getenv('OPENWEATHERMAP_API_KEY')
 
 temp_units_names = {
     'C': 'metric',
@@ -81,7 +84,7 @@ def _fetch_weather(pl, location_query, units, openweathermap_api_key):
 
 
 @lru_cache()
-def _weather(pl, *, openweathermap_api_key,
+def _weather(pl, *, openweathermap_api_key=OPENWEATHERMAP_API_KEY,
              condition_as_icon=True,
              humidity_format='{humidity:.0f}',
              location_query=None,


### PR DESCRIPTION
I have my powerline config files in my dotfiles repository and it is not possible for me to put my API key in the themes.json file. Therefore I made a small patch that takes the Openweathermap API key from the environment variable if it exists.